### PR TITLE
Fix "interface not loading" bug.

### DIFF
--- a/app/js/twister.js
+++ b/app/js/twister.js
@@ -60,7 +60,7 @@ window.Twister = function () {
 
     function getRandomPassword() {
         var k = 2; // number of 24bit randoms
-        return require('crypto').randomBytes(3 * k).toString('base64');
+        return require('crypto').randomBytes(3 * k).toString('hex');
     }
 
     settings.twisterdPath = settings.twisterdPath || appDir + ds + 'bin' + ds + 'twisterd';


### PR DESCRIPTION
Encoding to base64 can generate string with "/" character, and win.updateTheme() is not able to load interface in such case.

Encoding to hex guarantees valid characters.

There are second way to fix this bug - put encodeURIComponent inside win.updateTheme(), but I prefer current fix.
